### PR TITLE
fixed bug in which gridgen/restrict_psi_range changed x-point count to 1

### DIFF
--- a/tools/tokamak_grids/gridgen/restrict_psi_range.pro
+++ b/tools/tokamak_grids/gridgen/restrict_psi_range.pro
@@ -24,8 +24,8 @@ FUNCTION restrict_psi_range, critical, psi_outer
     inner_sep = 0
   ENDIF ELSE BEGIN
     ; Need to update inner_sep
-    w2 = WHERE(w EQ critical.inner_sep, count)
-    IF count EQ 1 THEN BEGIN
+    w2 = WHERE(w EQ critical.inner_sep, count2)
+    IF count2 EQ 1 THEN BEGIN
       inner_sep = w2[0]
     ENDIF ELSE BEGIN
       w = [critical.inner_sep]


### PR DESCRIPTION
Previously, in line 27, `count2` was `count`.  It overrode the X-point `count`in line 17, erroneously set it to 0 or 1, and returned it in `result.n_xpoint`.
Now, `count2` in line 27 is a distinct counter, and the correct `count` is returned in `result.n_xpoint`.
